### PR TITLE
feat(pdf): Allows creation of pdfs with custom dimensions

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,6 +11,9 @@ const HOST = '0.0.0.0';
 const PORT = 2078;
 const SPORT = 2079;
 
+const DEFAULT_WIDTH = 210 * 4;
+const DEFAULT_HEIGHT = 297 * 4;
+
 let ENABLE_HTTPS = false;
 if (process.env['ENABLE_HTTPS'] == "TRUE")
 	ENABLE_HTTPS = true;
@@ -48,11 +51,17 @@ function render(req, res) {
 	let renderID = renderCount;
 
 	const format = req.query['format'] || 'pdf';
-	const pageSize = req.query['pagesize'] || 'A4';
+	let pageSize = req.query['pagesize'] || 'A4';
 	const pageLandscape = req.query['pagelandscape'] === 'true';
 
-	let width = req.query['width'] || 210 * 4;
-	let height = req.query['height'] || 297 * 4;
+	let width = req.query['width'] || DEFAULT_WIDTH;
+	let height = req.query['height'] || DEFAULT_HEIGHT;
+
+	if (width !== DEFAULT_WIDTH || height !== DEFAULT_HEIGHT)
+		// need to set pageSize to undefined to allow the pdf function to make
+		// use of the width and height
+		pageSize = undefined;
+
 	let deviceScaleFactor = req.query['deviceScaleFactor'] || 1.0;
 	let topMargin = req.query['top'] || 0;
 	let bottomMargin = req.query['bottom'] || 0;
@@ -61,59 +70,6 @@ function render(req, res) {
 	let headerHtml;
 	let footerHtml;
 	let isHeaderFooter = false;
-
-	deviceScaleFactor = parseFloat(deviceScaleFactor);
-	width = parseInt(width);
-	height = parseInt(height);
-	topMargin = parseInt(topMargin);
-	bottomMargin = parseInt(bottomMargin);
-
-	if (deviceScaleFactor < 0.25 || deviceScaleFactor > 8) {
-		res.status(400).send('Invalid deviceScaleFactor. Must be between 0.25 and 8');
-		return;
-	}
-	if (width < 4 || height < 4) {
-		res.status(400).send('width and height must be at least 4');
-		return;
-	}
-
-	let maxSize = 2000;
-	if (width * deviceScaleFactor > maxSize || height * deviceScaleFactor > maxSize || width > maxSize || height > maxSize) {
-		// clamp our size, because it seems like something is going wrong when the image
-		// size gets too large.
-		// The symptom is this:
-		// The user tries to produce an A0 print preview, and the request for the preview
-		// just never returns (ie, from the HTTP client's point of view).
-		// The server logs aren't clear, but there are some suspicious thing, like:
-		// 2020-07-06 15:40:32.532 SAST (node:30) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 exit listeners added to [process]. Use emitter.setMaxListeners() to increase limit
-		// 2020-07-07 20:36:59.575 SAST TimeoutError: Timed out after 30000 ms while trying to connect to the browser! Only Chrome at revision r756035 is guaranteed to work.
-		// 2020-07-07 20:37:05.397 SAST at Timeout.onTimeout (/usr/src/htmlrender/node_modules/puppeteer/lib/launcher/BrowserRunner.js:200:20)
-		// 2020-07-07 20:37:05.398 SAST at listOnTimeout (internal/timers.js:549:17)
-		// 2020-07-07 20:37:05.398 SAST at processTimers (internal/timers.js:492:7)
-		// I suspect that something is going wrong that is catching puppeteer unaware. Or maybe we're simply not catching exceptions correctly.
-		// What happens is that the VM becomes completely unresponsive, and we are unable to SSH into it, and we have to reset it.
-		// The size of an A1 preview is 2384 x 1684, and that is fine, but an A0 causes us to hang.
-		// This is a small VM, with only 3.6 GB RAM.
-		// In these calculations, we need to take deviceScaleFactor into consideration, because page.setViewport()
-		// takes css pixels for it's width/height, so the real image width is width*deviceScaleFactor.
-		// OK.. one other massive thing...
-
-		// I don't really understand why, but I'm just throwing more fuel at this problem
-		let scale = deviceScaleFactor;
-		if (scale < 1)
-			scale = 1;
-
-		let aspect = width / height;
-		if (aspect >= 1) {
-			width = maxSize / scale;
-			height = width / aspect;
-		} else {
-			height = maxSize / scale;
-			width = height * aspect;
-		}
-		width = Math.floor(width);
-		height = Math.floor(height);
-	}
 
 	if (req.is('application/json')) {
 		// If you are using a header and/or footer, then you probably want to specify
@@ -167,6 +123,8 @@ function render(req, res) {
 				try {
 					pdf = await page.pdf({
 						format: pageSize,
+						width: width,
+						height: height,
 						landscape: pageLandscape,
 						printBackground: true,
 						displayHeaderFooter: isHeaderFooter,
@@ -188,6 +146,59 @@ function render(req, res) {
 				res.setHeader('content-type', 'application/pdf');
 				res.send(pdf);
 			} else if (format == 'png') {
+				deviceScaleFactor = parseFloat(deviceScaleFactor);
+				width = parseInt(width);
+				height = parseInt(height);
+				topMargin = parseInt(topMargin);
+				bottomMargin = parseInt(bottomMargin);
+
+				if (deviceScaleFactor < 0.25 || deviceScaleFactor > 8) {
+					res.status(400).send('Invalid deviceScaleFactor. Must be between 0.25 and 8');
+					return;
+				}
+				if (width < 4 || height < 4) {
+					res.status(400).send('width and height must be at least 4');
+					return;
+				}
+
+				let maxSize = 2000;
+				if (width * deviceScaleFactor > maxSize || height * deviceScaleFactor > maxSize || width > maxSize || height > maxSize) {
+					// clamp our size, because it seems like something is going wrong when the image
+					// size gets too large.
+					// The symptom is this:
+					// The user tries to produce an A0 print preview, and the request for the preview
+					// just never returns (ie, from the HTTP client's point of view).
+					// The server logs aren't clear, but there are some suspicious thing, like:
+					// 2020-07-06 15:40:32.532 SAST (node:30) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 exit listeners added to [process]. Use emitter.setMaxListeners() to increase limit
+					// 2020-07-07 20:36:59.575 SAST TimeoutError: Timed out after 30000 ms while trying to connect to the browser! Only Chrome at revision r756035 is guaranteed to work.
+					// 2020-07-07 20:37:05.397 SAST at Timeout.onTimeout (/usr/src/htmlrender/node_modules/puppeteer/lib/launcher/BrowserRunner.js:200:20)
+					// 2020-07-07 20:37:05.398 SAST at listOnTimeout (internal/timers.js:549:17)
+					// 2020-07-07 20:37:05.398 SAST at processTimers (internal/timers.js:492:7)
+					// I suspect that something is going wrong that is catching puppeteer unaware. Or maybe we're simply not catching exceptions correctly.
+					// What happens is that the VM becomes completely unresponsive, and we are unable to SSH into it, and we have to reset it.
+					// The size of an A1 preview is 2384 x 1684, and that is fine, but an A0 causes us to hang.
+					// This is a small VM, with only 3.6 GB RAM.
+					// In these calculations, we need to take deviceScaleFactor into consideration, because page.setViewport()
+					// takes css pixels for it's width/height, so the real image width is width*deviceScaleFactor.
+					// OK.. one other massive thing...
+
+					// I don't really understand why, but I'm just throwing more fuel at this problem
+					let scale = deviceScaleFactor;
+					if (scale < 1)
+						scale = 1;
+
+					let aspect = width / height;
+					if (aspect >= 1) {
+						width = maxSize / scale;
+						height = width / aspect;
+					} else {
+						height = maxSize / scale;
+						width = height * aspect;
+					}
+					width = Math.floor(width);
+					height = Math.floor(height);
+				}
+
 				console.info(`R:${renderID} Rendering png ${width} x ${height} @ ${deviceScaleFactor}`);
 				try {
 					await page.setViewport({


### PR DESCRIPTION
Moves a lot of code that is only needed by the png format path. This allows us to send the raw width and height to puppeteer for pdf's which allows callers to specify units with their widths and heights.

Refs: ASG-3281, ASG-3282